### PR TITLE
"Hide monster stats on location update and defeat/lose; remove traili…

### DIFF
--- a/script.js
+++ b/script.js
@@ -160,6 +160,7 @@ myFunction();
 
   */
  function update(location) {
+    monsterStats.style.display = 'none';
     button1.innerText = location["button text"][0];
     button2.innerText = location["button text"][1];
     button3.innerText = location["button text"][2];
@@ -358,5 +359,5 @@ function defeatMonster() {
   update(locations[4]);
 };
 function lose() {
-
+  monsterStats.style.display = 'none';
 };


### PR DESCRIPTION
…ng newline"

This commit hides the monster stats element when the `update` function is called, which occurs when the player moves to a new location or defeats